### PR TITLE
Re-enable use of Unsafe.getLong() on aarch64 devices other than Android

### DIFF
--- a/android/guava/src/com/google/common/hash/LittleEndianByteArray.java
+++ b/android/guava/src/com/google/common/hash/LittleEndianByteArray.java
@@ -244,7 +244,9 @@ final class LittleEndianByteArray {
        *
        */
       String arch = System.getProperty("os.arch");
-      if ("amd64".equals(arch)) {
+      String vendor = System.getProperty("java.vm.vendor");
+      if ("amd64".equals(arch) ||
+          ("aarch64".equals(arch) && !"The Android Project".equals(vendor))) {
         theGetter =
             ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)
                 ? UnsafeByteArray.UNSAFE_LITTLE_ENDIAN

--- a/guava/src/com/google/common/hash/LittleEndianByteArray.java
+++ b/guava/src/com/google/common/hash/LittleEndianByteArray.java
@@ -244,7 +244,9 @@ final class LittleEndianByteArray {
        *
        */
       String arch = System.getProperty("os.arch");
-      if ("amd64".equals(arch)) {
+      String vendor = System.getProperty("java.vm.vendor");
+      if ("amd64".equals(arch) ||
+          ("aarch64".equals(arch) && !"The Android Project".equals(vendor))) {
         theGetter =
             ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)
                 ? UnsafeByteArray.UNSAFE_LITTLE_ENDIAN


### PR DESCRIPTION
Test